### PR TITLE
Change to fork version togglv8 gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "togglv8"
+gem "togglv8", github: "ErebusBat/togglv8", branch: "fix-deprecation"
 # workaround for https://github.com/kanet77/togglv8/issues/17
 gem "awesome_print"
 gem "dotenv"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,35 @@
+GIT
+  remote: https://github.com/ErebusBat/togglv8
+  revision: b955d64a76810505b57ca5e466c91222124d25cd
+  branch: fix-deprecation
+  specs:
+    togglv8 (1.2.1)
+      faraday
+      logger
+      oj
+
 GEM
   remote: https://rubygems.org/
   specs:
     awesome_print (1.8.0)
     dotenv (2.7.5)
-    faraday (1.0.0)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
-    logger (1.4.2)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
+    logger (1.4.3)
     multipart-post (2.1.1)
-    oj (3.10.5)
-    togglv8 (1.2.1)
-      faraday
-      logger
-      oj
+    oj (3.11.5)
+    ruby2_keywords (0.0.4)
 
 PLATFORMS
   ruby
@@ -19,7 +37,7 @@ PLATFORMS
 DEPENDENCIES
   awesome_print
   dotenv
-  togglv8
+  togglv8!
 
 RUBY VERSION
    ruby 2.6.5p114


### PR DESCRIPTION
TogglのAPIのURLが変更されたため使用するGemをURLを差し替えたフォーク版のgemに変更したものです。